### PR TITLE
Cleanup stuff to make staticcheck happy

### DIFF
--- a/dawg_utils.go
+++ b/dawg_utils.go
@@ -5,214 +5,18 @@ package tapir
 
 import (
 	"bufio"
-	"crypto/rand"
 	"fmt"
-	"hash"
-	"math/big"
 	"os"
-	"sync"
-	"time"
 
-	"archive/zip"
 	"encoding/csv"
-	"errors"
 	"io"
 	"log"
-	"net/http"
-	"net/url"
 	"slices"
 
 	"github.com/miekg/dns"
 
 	"github.com/smhanov/dawg"
-	"github.com/spaolacci/murmur3"
 )
-
-type wellKnownDomainsTracker struct {
-	mutex sync.RWMutex
-	wellKnownDomainsData
-}
-
-type wellKnownDomainsData struct {
-	// Store a pointer to histogramCounters so we can assign to it without
-	// "cannot assign to struct field in map" issues
-	rotationTime  time.Time
-	dawgFinder    dawg.Finder
-	murmur3Hasher hash.Hash64
-}
-
-func newWellKnownDomainsTracker(dawgFinder dawg.Finder) (*wellKnownDomainsTracker, error) {
-
-	// Create random uint32, rand.Int takes a half-open range so we give it [0,4294967296)
-	randInt, err := rand.Int(rand.Reader, big.NewInt(1<<32))
-	if err != nil {
-		return nil, fmt.Errorf("newWellKnownDomainsTracker: %w", err)
-	}
-	murmur3Seed := uint32(randInt.Uint64())
-
-	murmur3Hasher := murmur3.New64WithSeed(murmur3Seed)
-
-	return &wellKnownDomainsTracker{
-		wellKnownDomainsData: wellKnownDomainsData{
-			dawgFinder:    dawgFinder,
-			murmur3Hasher: murmur3Hasher,
-		},
-	}, nil
-}
-
-func (wkd *wellKnownDomainsTracker) isWellKnown(name string) (bool, int) {
-
-	//	wkd.mutex.Lock()
-	//	defer wkd.mutex.Unlock()
-
-	index := wkd.dawgFinder.IndexOf(name)
-
-	// If this is is not a well-known domain just return as fast as possible
-	if index == -1 {
-		return false, 0
-	}
-
-	return true, index
-}
-
-func (wkd *wellKnownDomainsTracker) rotateTracker(dawgFile string, rotationTime time.Time) (*wellKnownDomainsData, error) {
-
-	dawgFinder, err := dawg.Load(dawgFile)
-	if err != nil {
-		return nil, fmt.Errorf("rotateTracker: dawg.Load(): %w", err)
-	}
-
-	prevWKD := &wellKnownDomainsData{}
-
-	// Swap the map in use so we can write parquet data outside of the write lock
-	wkd.mutex.Lock()
-	prevWKD.dawgFinder = wkd.dawgFinder
-	wkd.dawgFinder = dawgFinder
-	wkd.mutex.Unlock()
-
-	prevWKD.rotationTime = rotationTime
-
-	return prevWKD, nil
-}
-
-const (
-	domainsFileName = "top10milliondomains.csv.zip"
-	dawgFileName    = "well-known-domains.dawg"
-)
-
-func fetchFile(domainsFileName string) error {
-
-	if domainsFileName == "" {
-		return errors.New("fetchFile: domainsFileName cannot be empty")
-	}
-
-	file, err := os.Create(domainsFileName) // #nosec G304 -- The variable is a constant
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := file.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	url, err := url.Parse(fmt.Sprintf("%s/%s", "https://www.domcop.com/files/top", domainsFileName))
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("fetching %s\n", url)
-	resp, err := http.Get(url.String())
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := resp.Body.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	_, err = io.Copy(file, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func createDomainsList(domainsFileName string) ([]string, error) {
-
-	if domainsFileName == "" {
-		return nil, errors.New("extractFile: domainsFileName cannot be empty")
-	}
-
-	fmt.Println("creating domain list")
-	file, err := os.Open(domainsFileName) // #nosec G304 -- The variable is a constant
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err := file.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	r, err := zip.OpenReader(domainsFileName)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(r.File) != 1 {
-		return nil, errors.New("only one file is expected in the zip file")
-	}
-
-	sortedDomains := []string{}
-
-	for _, f := range r.File {
-		rc, err := f.Open()
-		if err != nil {
-			return nil, err
-		}
-		defer func() {
-			err = rc.Close()
-			if err != nil {
-				log.Fatal(err)
-			}
-		}()
-		csvReader := csv.NewReader(rc)
-
-		// Skip the first line containing the header
-		_, err = csvReader.Read()
-		if err != nil {
-			return nil, err
-		}
-
-		for {
-			record, err := csvReader.Read()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return nil, err
-			}
-
-			// Make sure the domain is fully qualified (includes
-			// the root domain dot at the end) as this is expected
-			// by miekg/dns when comparing against a dns question
-			// section name
-			sortedDomains = append(sortedDomains, dns.Fqdn(record[1]))
-		}
-		// The names need to be sorted when adding them to the dawg
-		// datastructure otherwise the operation can fail:
-		// panic: d.AddWord(): Words not in alphabetical order
-		slices.Sort(sortedDomains)
-	}
-
-	return sortedDomains, nil
-}
 
 func ParseCSV(srcfile string, dstmap map[string]TapirName, dontsort bool) ([]string, error) {
 	ifd, err := os.Open(srcfile)
@@ -303,24 +107,6 @@ func ParseText(srcfile string, dstmap map[string]TapirName, dontsort bool) ([]st
 		slices.Sort(sortedDomains)
 		return sortedDomains, nil
 	}
-}
-
-// Create a DAWG datastructure
-func makeDAWGWords(sortedDomains []string, dawgFileName string) error {
-	fmt.Printf("creating dawg file %s\n", dawgFileName)
-	dawg := dawg.New()
-	for _, domain := range sortedDomains {
-		dawg.Add(domain)
-	}
-
-	finder := dawg.Finish()
-
-	_, err := finder.Save(dawgFileName)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func CreateDawg(sortedDomains []string, outfile string) error {

--- a/mqtt_utils.go
+++ b/mqtt_utils.go
@@ -178,7 +178,7 @@ func NewMqttEngine(clientid string, pubsub uint8, lg *log.Logger) (*MqttEngine, 
 
 	c := paho.NewClient(paho.ClientConfig{
 		// XXX: The router seems to only bee needed for subscribers
-		Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) { me.MsgChan <- m }),
+		Router: paho.NewStandardRouterWithDefault((func(m *paho.Publish) { me.MsgChan <- m })),
 		// AutoReconnect: true,
 		Conn: conn,
 	})


### PR DESCRIPTION
```
dawg_utils.go:31:6: type wellKnownDomainsTracker is unused (U1000)
dawg_utils.go:36:6: type wellKnownDomainsData is unused (U1000)
dawg_utils.go:44:6: func newWellKnownDomainsTracker is unused (U1000)
dawg_utils.go:63:37: func (*wellKnownDomainsTracker).isWellKnown is unused (U1000)
dawg_utils.go:78:37: func (*wellKnownDomainsTracker).rotateTracker is unused (U1000)
dawg_utils.go:99:2: const domainsFileName is unused (U1000)
dawg_utils.go:100:2: const dawgFileName is unused (U1000)
dawg_utils.go:103:6: func fetchFile is unused (U1000)
dawg_utils.go:145:6: func createDomainsList is unused (U1000)
dawg_utils.go:309:6: func makeDAWGWords is unused (U1000)
mqtt_utils.go:181:11: paho.NewSingleHandlerRouter is deprecated: SingleHandlerRouter has been removed because it did not meet the requirements set out in the `Router` interface documentation. This function is only included to maintain compatibility, but there are limits (this version does not ignore calls to `RegisterHandler`).  (SA1019)
make: *** [lint] Error 1
```