### PR TITLE
Print tag mask (as integer) with colourlists command

### DIFF
--- a/cmd/colourlists.go
+++ b/cmd/colourlists.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+    "strconv"
     "strings"
 
 	"github.com/dnstapir/tapir"
@@ -19,25 +20,25 @@ var ColourlistsCmd = &cobra.Command{
 		if resp.Error {
 			fmt.Printf("%s\n", resp.ErrorMsg)
 		}
-        fmtstring := "%-35s|%-20s|%-10s|%-10s\n"
+        fmtstring := "%-75s|%-20s|%-20s|%-10s|%-10s\n"
 
         // print the column headings
-        fmt.Printf(fmtstring, "Domain", "Source", "Src Fmt", "Colour")
-        fmt.Println(strings.Repeat("-", 78)) // A nice ruler over the data rows
+        fmt.Printf(fmtstring, "Domain", "Source", "Src Fmt", "Colour", "Flags")
+        fmt.Println(strings.Repeat("-", 135)) // A nice ruler over the data rows
 
 		for _, l := range resp.Lists["whitelist"] {
             for _, n := range l.Names {
-                fmt.Printf(fmtstring, n.Name, l.Name, "-", "white")
+                fmt.Printf(fmtstring, n.Name, l.Name, "-", "white", "-")
             }
 		}
 		for _, l := range resp.Lists["blacklist"] {
             for _, n := range l.Names {
-                fmt.Printf(fmtstring, n.Name, l.Name, "-", "black")
+                fmt.Printf(fmtstring, n.Name, l.Name, "-", "black", "-")
             }
 		}
 		for _, l := range resp.Lists["greylist"] {
             for _, n := range l.Names {
-                fmt.Printf(fmtstring, n.Name, l.Name, l.SrcFormat, "grey")
+                fmt.Printf(fmtstring, n.Name, l.Name, l.SrcFormat, "grey", strconv.Itoa(int(n.TagMask)))
             }
 		}
 	},

--- a/cmd/colourlists.go
+++ b/cmd/colourlists.go
@@ -2,13 +2,12 @@ package cmd
 
 import (
 	"fmt"
-    "strconv"
-    "strings"
+	"strconv"
+	"strings"
 
 	"github.com/dnstapir/tapir"
 	"github.com/spf13/cobra"
 )
-
 
 var ColourlistsCmd = &cobra.Command{
 	Use:   "colourlists",
@@ -20,28 +19,26 @@ var ColourlistsCmd = &cobra.Command{
 		if resp.Error {
 			fmt.Printf("%s\n", resp.ErrorMsg)
 		}
-        fmtstring := "%-75s|%-20s|%-20s|%-10s|%-10s\n"
+		fmtstring := "%-75s|%-20s|%-20s|%-10s|%-10s\n"
 
-        // print the column headings
-        fmt.Printf(fmtstring, "Domain", "Source", "Src Fmt", "Colour", "Flags")
-        fmt.Println(strings.Repeat("-", 135)) // A nice ruler over the data rows
+		// print the column headings
+		fmt.Printf(fmtstring, "Domain", "Source", "Src Fmt", "Colour", "Flags")
+		fmt.Println(strings.Repeat("-", 135)) // A nice ruler over the data rows
 
 		for _, l := range resp.Lists["whitelist"] {
-            for _, n := range l.Names {
-                fmt.Printf(fmtstring, n.Name, l.Name, "-", "white", "-")
-            }
+			for _, n := range l.Names {
+				fmt.Printf(fmtstring, n.Name, l.Name, "-", "white", "-")
+			}
 		}
 		for _, l := range resp.Lists["blacklist"] {
-            for _, n := range l.Names {
-                fmt.Printf(fmtstring, n.Name, l.Name, "-", "black", "-")
-            }
+			for _, n := range l.Names {
+				fmt.Printf(fmtstring, n.Name, l.Name, "-", "black", "-")
+			}
 		}
 		for _, l := range resp.Lists["greylist"] {
-            for _, n := range l.Names {
-                fmt.Printf(fmtstring, n.Name, l.Name, l.SrcFormat, "grey", strconv.Itoa(int(n.TagMask)))
-            }
+			for _, n := range l.Names {
+				fmt.Printf(fmtstring, n.Name, l.Name, l.SrcFormat, "grey", strconv.Itoa(int(n.TagMask)))
+			}
 		}
 	},
 }
-
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced output format for the `ColourlistsCmd` command, now displaying an additional "Flags" column for improved information clarity. 
- **Bug Fixes**
	- Adjusted separator line to align with the new output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->